### PR TITLE
[HOU-166]: Docker Image Tags and PR branch refs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,6 +2,7 @@ name: Test gha-env-variables
 
 on:
   - push
+  - pull_request
 
 jobs:
   test-gha-env-variables:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Export Environment Variables
         id: export-vars
-        uses: dmsi-io/gha-env-variables@feature/HOU-166
+        uses: dmsi-io/gha-env-variables@main
         with:
           TLD: ${{ secrets.TLD }}
           GCP_PROJECT_ID: test-project-id
@@ -38,7 +38,7 @@ jobs:
     name: Test gha-env-variables (override defaults)
     steps:
       - name: Export Environment Variables (override defaults)
-        uses: dmsi-io/gha-env-variables@feature/HOU-166
+        uses: dmsi-io/gha-env-variables@main
         with:
           TLD: agility.dmsi.io
           GCP_PROJECT_ID: test-project-id

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - name: Export Environment Variables
         id: export-vars
-        uses: dmsi-io/gha-env-variables@main
+        uses: dmsi-io/gha-env-variables@feature/HOU-166
         with:
           TLD: ${{ secrets.TLD }}
           GCP_PROJECT_ID: test-project-id
@@ -38,7 +38,7 @@ jobs:
     name: Test gha-env-variables (override defaults)
     steps:
       - name: Export Environment Variables (override defaults)
-        uses: dmsi-io/gha-env-variables@main
+        uses: dmsi-io/gha-env-variables@feature/HOU-166
         with:
           TLD: agility.dmsi.io
           GCP_PROJECT_ID: test-project-id

--- a/action.yml
+++ b/action.yml
@@ -81,10 +81,22 @@ runs:
         echo "::set-output name=SERVICE_NAME::$SERVICE_NAME"
       shell: bash
 
+    - name: Docker Tag
+      id: docker_tag
+      run: |
+        if [ "${{ github.github.ref_type }}" = "tag" ]; then
+          echo "::set-output name=tag_name::${{ steps.get_ref.outputs.ref_name }}"
+
+        else
+          echo "::set-output name=tag_name::$SHORT_SHA"
+
+        fi
+      shell: bash
+
     - name: BUILD_IMAGE
       id: BUILD_IMAGE
       run: |
-        BUILD_IMAGE=${{ inputs.REGISTRY_HOSTNAME }}/${{ inputs.GCP_PROJECT_ID }}/$SERVICE_NAME:$SHORT_SHA
+        BUILD_IMAGE=${{ inputs.REGISTRY_HOSTNAME }}/${{ inputs.GCP_PROJECT_ID }}/$SERVICE_NAME:${{ steps.docker_tag.outputs.tag_name }}
 
         echo "BUILD_IMAGE=$BUILD_IMAGE"
         echo "BUILD_IMAGE=$BUILD_IMAGE" >> $GITHUB_ENV

--- a/action.yml
+++ b/action.yml
@@ -84,7 +84,7 @@ runs:
     - name: Docker Tag
       id: docker_tag
       run: |
-        if [ "${{ github.github.ref_type }}" = "tag" ]; then
+        if [ "${{ github.ref_type }}" = "tag" ]; then
           echo "::set-output name=tag_name::${{ steps.get_ref.outputs.ref_name }}"
 
         else

--- a/action.yml
+++ b/action.yml
@@ -12,11 +12,10 @@ inputs:
   TLD:
     description: 'Top Level Domain to create subdomain on.'
     required: true
-  NAMESPACE: 
+  NAMESPACE:
     description: 'Allows to override the desired NAMESPACE variable'
     required: false
-    default: ${{ github.ref_name }}
-  SERVICE_NAME: 
+  SERVICE_NAME:
     description: 'Allows to override the desired SERVICE_NAME variable'
     required: false
     default: ${{ github.repository }}
@@ -54,10 +53,16 @@ runs:
         echo "::set-output name=SHORT_SHA::$SHORT_SHA"
       shell: bash
 
+    - name: Get Ref
+      id: get_ref
+      uses: dmsi-io/gha-get-ref@v1
+      with:
+        custom_ref: ${{ inputs.NAMESPACE }}
+
     - name: NAMESPACE
       id: NAMESPACE
       run: |
-        NAMESPACE=$(${{ github.action_path }}/clean_variable.sh ${{ inputs.NAMESPACE }})
+        NAMESPACE=$(${{ github.action_path }}/clean_variable.sh ${{ steps.get_ref.outputs.ref_name }})
 
         echo "NAMESPACE=$NAMESPACE"
         echo "NAMESPACE=$NAMESPACE" >> $GITHUB_ENV
@@ -69,10 +74,10 @@ runs:
       id: SERVICE_NAME
       run: |
         SERVICE_NAME=$(${{ github.action_path }}/clean_variable.sh ${{ inputs.SERVICE_NAME }})
-        
+
         echo "SERVICE_NAME=$SERVICE_NAME"
         echo "SERVICE_NAME=$SERVICE_NAME" >> $GITHUB_ENV
-        
+
         echo "::set-output name=SERVICE_NAME::$SERVICE_NAME"
       shell: bash
 


### PR DESCRIPTION
## 📑 Description
- Utilizes new [gha-get-ref](https://github.com/dmsi-io/gha-get-ref) action to retrieve correct ref regardless of trigger
- Will instead provide git tag to Docker image tag when triggered by tag

Closes: https://github.com/dmsi-io/gha-env-variables/issues/3