### PR TITLE
[HOU-166]: Docker image tags match release semver

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -84,8 +84,15 @@ runs:
     - name: Docker Tag
       id: docker_tag
       run: |
+        SEMVER_REGEX="^(v*0|v*[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$"
+        RELEASE_REGEX="release/*"
+        REF="${{ steps.get_ref.outputs.ref_name }}"
+
         if [ "${{ github.ref_type }}" = "tag" ]; then
-          echo "::set-output name=tag_name::${{ steps.get_ref.outputs.ref_name }}"
+          echo "::set-output name=tag_name::$REF"
+
+        elif [[ "$REF" =~ $RELEASE_REGEX ]] && [[ "${REF##*/}" =~ $SEMVER_REGEX ]]; then
+          echo "::set-output name=tag_name::${REF##*/}"
 
         else
           echo "::set-output name=tag_name::$SHORT_SHA"


### PR DESCRIPTION
## 📑 Description
This change allows branches that fall under `release/<semver>` format to instead create the BUILD_IMAGE variable with the semver tag.